### PR TITLE
feat: support dataclasses with 'field()' definitions

### DIFF
--- a/strawberry/object_type.py
+++ b/strawberry/object_type.py
@@ -96,7 +96,7 @@ def _check_field_annotations(cls: Type):
             raise MissingFieldAnnotationError(field_name, cls)
 
 
-def _wrap_dataclass(cls: Type):
+def _wrap_dataclass(cls: Type, skip_wrapping: bool = False):
     """Wrap a strawberry.type class with a dataclass and check for any issues
     before doing so"""
 
@@ -112,7 +112,10 @@ def _wrap_dataclass(cls: Type):
     else:
         dclass_kwargs["init"] = False
 
-    dclass = dataclasses.dataclass(cls, **dclass_kwargs)
+    if skip_wrapping:
+        dclass = cls
+    else:
+        dclass = dataclasses.dataclass(cls, **dclass_kwargs)
 
     if sys.version_info < (3, 10):
         add_custom_init_fn(dclass)
@@ -218,6 +221,7 @@ def type(
     description: Optional[str] = None,
     directives: Optional[Sequence[object]] = (),
     extend: bool = False,
+    skip_dataclass_wrapping: bool = False,
 ) -> Union[T, Callable[[T], T]]:
     """Annotates a class as a GraphQL type.
 
@@ -238,7 +242,7 @@ def type(
                 exc = ObjectIsNotClassError.type
             raise exc(cls)
 
-        wrapped = _wrap_dataclass(cls)
+        wrapped = _wrap_dataclass(cls, skip_dataclass_wrapping)
         return _process_type(
             wrapped,
             name=name,


### PR DESCRIPTION
The @gql.type annotation internally wraps classes to be dataclasses. Unfortunately, this happens whether or not the original class is already a dataclass.

A small example of how this fails:

```python
from dataclasses import dataclass, field

from dacite import from_dict
from strawberry_django_plus import gql

@gql.type
@dataclass
class Vehicle:
    powertrain: str
    pcm_modules: list[str] = field(
        default_factory=list,
    )

data = {
    "powertrain": "hybrid",
}

print(from_dict(Vehicle, data))
```

This patch adds an optional parameter that will skip wrapping a class as a dataclass. I did originally try checking to see if the `cls` object was a dataclass (with `dataclasses.is_dataclass()`) but this caused issues with some built-in Strawberry types. I also tried copying over the original field definitions or `default_factory`/`default` attributes, but I wasn't able to find a way to access this information on the original dataclass. A way to detect this case and handle it would certainly be preferred to adding yet another flag.